### PR TITLE
【fixed】`rails g`コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,9 @@ module Achieve
 
     config.generators do |g|
 
+      g.assets     false
+      g.helper     false
+
     g.test_framework :rspec,
       fixtures: true,
       view_specs: false,


### PR DESCRIPTION
#1 

config/application.rbのconfig.generators do |g|のコード
の中に以下を追記

      g.assets     false
      g.helper     false
   