### PR TITLE
【fixed】デバッグツールを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,10 @@ group :development do
 gem 'dotenv-rails'
 # Access an IRB console on exception pages or by using <%= console %> in views
 gem 'web-console', '~> 2.0'
+
+gem 'pry-rails'
+gem 'better_errors'
+gem 'binding_of_caller'
 end
 
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,10 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.4)
     bcrypt (3.1.11)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
@@ -83,6 +87,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -316,6 +321,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -354,6 +360,12 @@ GEM
       rack
     orm_adapter (0.5.0)
     pg (0.21.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (2.0.5)
     pusher (1.3.1)
       httpclient (~> 2.7)
@@ -455,6 +467,7 @@ GEM
     selenium-webdriver (3.5.1)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.1)
@@ -506,6 +519,8 @@ PLATFORMS
 
 DEPENDENCIES
   activeresource
+  better_errors
+  binding_of_caller
   byebug
   cancan
   capistrano (= 3.6.0)
@@ -532,6 +547,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-twitter
   pg
+  pry-rails
   pusher
   rails (= 4.2.3)
   rails_12factor

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -6,8 +6,8 @@ class BlogsController < ApplicationController
     @users = User.all
     @blogs = Blog.all
     @blogs.order(created_at: :asc)
-    #raise
     #binding.pry
+    #raise
   end
 
   def new


### PR DESCRIPTION
#2 

gemfileのgroup :development doのコード内に
以下を追記
gem 'pry-rails'
gem 'better_errors'
gem 'binding_of_caller'

テストとして、blogs_controller.rbのindexアクション内に
を追記（以下のコードはpushの際はコメントアウトとしている）
binding.pry
raise（エラーを起こすため）